### PR TITLE
modify local_interface to interface

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -14,7 +14,7 @@ import (
 var (
 	bgpSubsystem = "bgp"
 
-	bgpPeerLabels     = []string{"peer", "local_interface"}
+	bgpPeerLabels     = []string{"peer", "interface"}
 	bgpRIBLabels      = []string{"address_family"}
 	bgpPeerRIBLabels  = append(bgpPeerLabels, bgpRIBLabels...)
 	bgpPeerTypeLabels = []string{"type"}


### PR DESCRIPTION
in the go bgp, i would like to standardize on just interface like the bgp labels vs local_interface. 