### PR TITLE
add junos ipsec collector for basic tunnel status

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The below metrics are currently implemented.
 - Environment, from `show chassis environment`.
 - Power, from `show chassis power detail`.
 - Route Engine, from `show chassis routing-engine`.
+- IPsec, from `show security ipsec security-associations` and `show security ipsec inactive-tunnels`.
 
 ### BGP: junos_bgp_peer_types_up
 Junos Exporter exposes a special metric, `junos_bgp_peer_types_up`, that can be used in scenarios where you want to create Prometheus queries that report on the number of types of BGP peers that are currently established, such as for Alertmanager. To implement this metric, a JSON formatted description must be configured on your BGP group. Junos Exporter will then use the value from the keys specific under the `bgp_peer_type_keys` configuration, and aggregate all BGP peers that are currently established and configured with that type.

--- a/collector/ipsec.go
+++ b/collector/ipsec.go
@@ -1,0 +1,170 @@
+package collector
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"github.com/Juniper/go-netconf/netconf"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ipsecSubsystem   = "ipsec"
+  totalIpsecErrors = 0.0
+
+  ipsecLabels = map[string][]string{"TunnelInformation": []string{"saremotegateway", "satunnelindex"}}
+	ipsecDesc   = map[string]*prometheus.Desc{
+		"TunnelStatusUp":   colPromDesc(ipsecSubsystem, "tunnel_status_up", "Tunnel Status (1 UP, 0 DOWN)", ipsecLabels["TunnelInformation"]),
+	}
+)
+
+// EnvCollector collects environment metrics, implemented as per the Collector interface.
+type IpsecCollector struct{}
+
+// NewEnvCollector returns a new EnvCollector.
+func NewIpsecCollector() *IpsecCollector {
+	return &IpsecCollector{}
+}
+
+// Name of the collector.
+func (*IpsecCollector) Name() string {
+	return ipsecSubsystem
+}
+
+// Get metrics and send to the Prometheus.Metric channel.
+func (c *IpsecCollector) Get(ch chan<- prometheus.Metric, conf Config) ([]error, float64) {
+	errors := []error{}
+	s, err := netconf.DialSSH(conf.SSHTarget, conf.SSHClientConfig)
+	if err != nil {
+		totalIpsecErrors++
+		errors = append(errors, fmt.Errorf("could not connect to %q: %s", conf.SSHTarget, err))
+		return errors, totalIpsecErrors
+	}
+	defer s.Close()
+
+  // IPsec inactive tunnels
+	reply, err := s.Exec(netconf.RawMethod(`<get-inactive-tunnels/>`))
+	if err != nil {
+		totalIpsecErrors++
+		errors = append(errors, fmt.Errorf("could not execute netconf RPC call: %s", err))
+		return errors, totalIpsecErrors
+	}
+
+	if err := processIpsecInactiveNetconfReply(reply, ch, conf.SSHTarget); err != nil {
+		totalIpsecErrors++
+		errors = append(errors, err)
+	}
+
+  // IPsec active tunnels
+	reply, err = s.Exec(netconf.RawMethod(`<get-security-associations-information/>`))
+	if err != nil {
+		totalIpsecErrors++
+		errors = append(errors, fmt.Errorf("could not execute netconf RPC call: %s", err))
+		return errors, totalIpsecErrors
+	}
+
+	if err := processIpsecActiveNetconfReply(reply, ch); err != nil {
+		totalIpsecErrors++
+		errors = append(errors, err)
+	}
+
+	return errors, totalIpsecErrors
+}
+
+func processIpsecInactiveNetconfReply(reply *netconf.RPCReply, ch chan<- prometheus.Metric, sshTarget string) error {
+	var netconfInactiveTunnelReply InactiveTunnelReply
+
+	if err := xml.Unmarshal([]byte(reply.RawReply), &netconfInactiveTunnelReply); err != nil {
+		return fmt.Errorf("could not unmarshal netconf inactive tunnel reply xml: %s", err)
+	}
+
+  // Send tunnel status of inactive tunnels to Prometheus channel.
+  // Set tunnel_status_up to 0
+  for _, ipsecData := range netconfInactiveTunnelReply.IpsecUnestablishedTunnelInformation.IpsecSecurityAssociationsBlock {
+    saRemoteGateway := strings.Trim(ipsecData.IpsecSecurityAssociations.SaRemoteGateway, "\n")
+    saTunnelIndex := strings.Trim(ipsecData.IpsecSecurityAssociations.SaTunnelIndex, "\n")
+    ch <- prometheus.MustNewConstMetric(ipsecDesc["TunnelStatusUp"], prometheus.GaugeValue, 0, saRemoteGateway, saTunnelIndex)
+  }
+
+  return nil
+}
+
+// Process active ipsec SAs.
+func processIpsecActiveNetconfReply(reply *netconf.RPCReply, ch chan<- prometheus.Metric) error {
+	var netconfActiveTunnelReply ActiveTunnelReply
+
+	if err := xml.Unmarshal([]byte(reply.RawReply), &netconfActiveTunnelReply); err != nil {
+		return fmt.Errorf("could not unmarshal netconf active tunnel reply xml: %s", err)
+	}
+
+  // Send tunnel status of active tunnels to Prometheus channel.
+  // Set tunnel_status_up to 1
+  for _, ipsecData := range netconfActiveTunnelReply.IpsecSecurityAssociationsInformation.IpsecSecurityAssociationsBlock {
+    saRemoteGateway := strings.Trim(ipsecData.IpsecSecurityAssociations.SaRemoteGateway, "\n")
+    saTunnelIndex := strings.Trim(ipsecData.IpsecSecurityAssociations.SaTunnelIndex, "\n")
+    ch <- prometheus.MustNewConstMetric(ipsecDesc["TunnelStatusUp"], prometheus.GaugeValue, 1, saRemoteGateway, saTunnelIndex)
+  }
+
+  return nil
+}
+
+type InactiveTunnelReply struct {
+	XMLName                             xml.Name `xml:"rpc-reply"`
+	Text                                string   `xml:",chardata"`
+	Junos                               string   `xml:"junos,attr"`
+	MessageID                           string   `xml:"message-id,attr"`
+	Xmlns                               string   `xml:"xmlns,attr"`
+	IpsecUnestablishedTunnelInformation struct {
+		Text                                         string `xml:",chardata"`
+		Style                                        string `xml:"style,attr"`
+		TotalInactiveTunnels                         string `xml:"total-inactive-tunnels"`
+		TotalInactiveTunnelsWithEstablishImmediately string `xml:"total-inactive-tunnels-with-establish-immediately"`
+		IpsecSecurityAssociationsBlock               []struct {
+			Text                      string `xml:",chardata"`
+			IpsecSecurityAssociations struct {
+				Text                  string `xml:",chardata"`
+				SaTunnelIndex         string `xml:"sa-tunnel-index"`
+				SaRemoteGateway       string `xml:"sa-remote-gateway"`
+				SaPort                string `xml:"sa-port"`
+				SaTunnelEventTime     string `xml:"sa-tunnel-event-time"`
+				SaTunnelEvent         string `xml:"sa-tunnel-event"`
+				SaTunnelEventNumTimes string `xml:"sa-tunnel-event-num-times"`
+			} `xml:"ipsec-security-associations"`
+		} `xml:"ipsec-security-associations-block"`
+	} `xml:"ipsec-unestablished-tunnel-information"`
+} 
+
+type ActiveTunnelReply struct {
+	XMLName                              xml.Name `xml:"rpc-reply"`
+	Text                                 string   `xml:",chardata"`
+	Junos                                string   `xml:"junos,attr"`
+	IpsecSecurityAssociationsInformation struct {
+		Text                           string `xml:",chardata"`
+		Style                          string `xml:"style,attr"`
+		TotalActiveTunnels             string `xml:"total-active-tunnels"`
+		IpsecSecurityAssociationsBlock []struct {
+			Text                      string `xml:",chardata"`
+			SaBlockState              string `xml:"sa-block-state"`
+			IpsecSecurityAssociations struct {
+				Text                     string `xml:",chardata"`
+				SaDirection              string `xml:"sa-direction"`
+				SaTunnelIndex            string `xml:"sa-tunnel-index"`
+				SaSpi                    string `xml:"sa-spi"`
+				SaAuxSpi                 string `xml:"sa-aux-spi"`
+				SaRemoteGateway          string `xml:"sa-remote-gateway"`
+				SaPort                   string `xml:"sa-port"`
+				SaVpnMonitoringState     string `xml:"sa-vpn-monitoring-state"`
+				SaProtocol               string `xml:"sa-protocol"`
+				SaEspEncryptionAlgorithm string `xml:"sa-esp-encryption-algorithm"`
+				SaHmacAlgorithm          string `xml:"sa-hmac-algorithm"`
+				SaHardLifetime           string `xml:"sa-hard-lifetime"`
+				SaLifesizeRemaining      string `xml:"sa-lifesize-remaining"`
+				SaVirtualSystem          string `xml:"sa-virtual-system"`
+			} `xml:"ipsec-security-associations"`
+		} `xml:"ipsec-security-associations-block"`
+	} `xml:"ipsec-security-associations-information"`
+	Cli struct {
+		Text   string `xml:",chardata"`
+		Banner string `xml:"banner"`
+	} `xml:"cli"`
+} 

--- a/junos_exporter.go
+++ b/junos_exporter.go
@@ -41,6 +41,7 @@ func initCollectors() {
 	collectors = append(collectors, collector.NewEnvCollector())
 	collectors = append(collectors, collector.NewPowerCollector())
 	collectors = append(collectors, collector.NewRECollector())
+  collectors = append(collectors, collector.NewIpsecCollector())
 }
 
 func validateRequest(configParam string, targetParam string) error {


### PR DESCRIPTION
## Summary

Adding ipsec collector equivalent SRX commands

> show security ipsec inactive-tunnels
> show security ipsec security-associations

## Test output

```
# HELP junos_collector_up Whether the collector's last scrape was successful (1 = successful, 0 = unsuccessful).
# TYPE junos_collector_up gauge
junos_collector_up{collector="ipsec"} 1
# HELP junos_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which junos_exporter was built.
# TYPE junos_exporter_build_info gauge
junos_exporter_build_info{branch="",goversion="go1.13.8",revision="",version=""} 1
# HELP junos_ipsec_tunnel_status_up Tunnel Status (1 UP, 0 DOWN)
# TYPE junos_ipsec_tunnel_status_up gauge
junos_ipsec_tunnel_status_up{saremotegateway="<removed>",satunnelindex="131075"} 0
junos_ipsec_tunnel_status_up{saremotegateway="<removed>",satunnelindex="67108866"} 1
junos_ipsec_tunnel_status_up{saremotegateway="<removed>",satunnelindex="67108867"} 1
junos_ipsec_tunnel_status_up{saremotegateway="<removed>",satunnelindex="67108868"} 1
junos_ipsec_tunnel_status_up{saremotegateway="<removed>",satunnelindex="67108865"} 0
junos_ipsec_tunnel_status_up{saremotegateway="<removed>",satunnelindex="131073"} 0
# HELP junos_scrape_duration_seconds Time it took for a collector's scrape to complete.
# TYPE junos_scrape_duration_seconds gauge
junos_scrape_duration_seconds{collector="ipsec"} 8.481809263
# HELP junos_scrape_errors_total Total number of errors from a collector.
# TYPE junos_scrape_errors_total gauge
junos_scrape_errors_total{collector="ipsec"} 0
# HELP junos_scrapes_total Total number of times Junos has been scraped.
# TYPE junos_scrapes_total counter
junos_scrapes_total 1

```

config change:

```
[...]
enabled_collectors:
  - ipsec
[...]
```

Please let me know if you need more specifics. 

Thanks
Chris