### PR TITLE
fix: use TrimSuffix for speed parsing and skip on parse error

### DIFF
--- a/collector/interface.go
+++ b/collector/interface.go
@@ -234,17 +234,15 @@ func processIfaceNetconfReply(reply *netconf.RPCReply, ch chan<- prometheus.Metr
 		}
 		if len(ifaceData.Speed.Text) > 0 {
 			if strings.Contains(strings.TrimSpace(ifaceData.Speed.Text), "Gbps") {
-				i, err := strconv.Atoi(strings.TrimRight(strings.TrimSpace(ifaceData.Speed.Text), "Gbps"))
-				if err != nil {
-					return err
+				i, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(ifaceData.Speed.Text), "Gbps"))
+				if err == nil {
+					ch <- prometheus.MustNewConstMetric(ifaceDesc["SpeedBytes"], prometheus.GaugeValue, float64(i*125000000), ifaceLabels...)
 				}
-				ch <- prometheus.MustNewConstMetric(ifaceDesc["SpeedBytes"], prometheus.GaugeValue, float64(i*125000000), ifaceLabels...)
 			} else if strings.Contains(strings.TrimSpace(ifaceData.Speed.Text), "mbps") {
-				i, err := strconv.Atoi(strings.TrimRight(strings.TrimSpace(ifaceData.Speed.Text), "mbps"))
-				if err != nil {
-					return err
+				i, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(ifaceData.Speed.Text), "mbps"))
+				if err == nil {
+					ch <- prometheus.MustNewConstMetric(ifaceDesc["SpeedBytes"], prometheus.GaugeValue, float64(i*125000), ifaceLabels...)
 				}
-				ch <- prometheus.MustNewConstMetric(ifaceDesc["SpeedBytes"], prometheus.GaugeValue, float64(i*125000), ifaceLabels...)
 			}
 		}
 


### PR DESCRIPTION
TrimRight strips individual characters from a set, not a suffix string.
Replace with TrimSuffix for correctness. Also change return-on-error
to skip-on-error so one unparseable speed doesn't abort the entire
interface scrape.